### PR TITLE
Support nullable types

### DIFF
--- a/parcelable-compose/src/androidMain/kotlin/com.chrynan.parcelable.compose/AndroidParcelableSaverUtils.kt
+++ b/parcelable-compose/src/androidMain/kotlin/com.chrynan.parcelable.compose/AndroidParcelableSaverUtils.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 
 @ExperimentalSerializationApi
-internal class AndroidParcelableSaver<T : Any>(
+internal class AndroidParcelableSaver<T>(
     private val parcelable: Parcelable = Parcelable.Default,
     private val serializer: KSerializer<T>
 ) : Saver<T, Bundle> {
@@ -25,7 +25,7 @@ internal class AndroidParcelableSaver<T : Any>(
 
 @SuppressLint("ComposableNaming")
 @ExperimentalSerializationApi
-internal actual fun <T : Any> InternalParcelableSaver(
+internal actual fun <T> InternalParcelableSaver(
     parcelable: Parcelable,
     serializer: KSerializer<T>
 ): Saver<T, *> =

--- a/parcelable-compose/src/commonMain/kotlin/com.chrynan.parcelable.compose/ParcelableSaverUtils.kt
+++ b/parcelable-compose/src/commonMain/kotlin/com.chrynan.parcelable.compose/ParcelableSaverUtils.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 
 @ExperimentalSerializationApi
-internal expect fun <T : Any> InternalParcelableSaver(
+internal expect fun <T> InternalParcelableSaver(
     parcelable: Parcelable = Parcelable.Default,
     serializer: KSerializer<T>
 ): Saver<T, *>
@@ -18,7 +18,7 @@ internal expect fun <T : Any> InternalParcelableSaver(
  * Creates a [Saver] that uses the provided [parcelable] and [serializer] to save and restore the value.
  */
 @ExperimentalSerializationApi
-fun <T : Any> ParcelableSaver(
+fun <T> ParcelableSaver(
     parcelable: Parcelable = Parcelable.Default,
     serializer: KSerializer<T>
 ): Saver<T, *> = InternalParcelableSaver(
@@ -48,7 +48,7 @@ fun <T : Any> rememberSavable(
  */
 @Composable
 @ExperimentalSerializationApi
-fun <T : Any> rememberSaveable(
+fun <T> rememberSaveable(
     vararg inputs: Any?,
     parcelable: Parcelable = Parcelable.Default,
     serializer: KSerializer<T>,

--- a/parcelable-compose/src/jsMain/kotlin/com.chrynan.parcelable.compose/JsParcelableSaverUtils.kt
+++ b/parcelable-compose/src/jsMain/kotlin/com.chrynan.parcelable.compose/JsParcelableSaverUtils.kt
@@ -28,7 +28,7 @@ internal class JsParcelableSaver<T>(
 
 @Suppress("FunctionName")
 @ExperimentalSerializationApi
-internal actual fun <T : Any> InternalParcelableSaver(
+internal actual fun <T> InternalParcelableSaver(
     parcelable: Parcelable,
     serializer: KSerializer<T>
 ): Saver<T, *> =

--- a/parcelable-compose/src/jvmMain/kotlin/com/chrynan/parcelable/compose/JvmParcelableSaverUtils.kt
+++ b/parcelable-compose/src/jvmMain/kotlin/com/chrynan/parcelable/compose/JvmParcelableSaverUtils.kt
@@ -31,7 +31,7 @@ internal class JvmParcelableSaver<T>(
 }
 
 @ExperimentalSerializationApi
-internal actual fun <T : Any> InternalParcelableSaver(
+internal actual fun <T> InternalParcelableSaver(
     parcelable: Parcelable,
     serializer: KSerializer<T>
 ): Saver<T, *> =

--- a/parcelable-core/src/androidMain/kotlin/com/chrynan/parcelable/core/AndroidBundleUtils.kt
+++ b/parcelable-core/src/androidMain/kotlin/com/chrynan/parcelable/core/AndroidBundleUtils.kt
@@ -6,9 +6,10 @@ import android.os.Bundle
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.serializer
 
 @ExperimentalSerializationApi
-inline fun <reified T : Any> Bundle.putParcelable(
+inline fun <reified T> Bundle.putParcelable(
     key: String,
     value: T,
     parceler: AndroidParceler
@@ -17,12 +18,12 @@ inline fun <reified T : Any> Bundle.putParcelable(
 }
 
 @ExperimentalSerializationApi
-inline fun <reified T : Any> Bundle.putParcelable(key: String, value: T, parcelable: Parcelable = Parcelable.Default) {
+inline fun <reified T> Bundle.putParcelable(key: String, value: T, parcelable: Parcelable = Parcelable.Default) {
     putBundle(key, parcelable.encodeToBundle(value))
 }
 
 @ExperimentalSerializationApi
-fun <T : Any> Bundle.putParcelable(
+fun <T> Bundle.putParcelable(
     key: String,
     value: T,
     parcelable: Parcelable = Parcelable.Default,
@@ -32,19 +33,19 @@ fun <T : Any> Bundle.putParcelable(
 }
 
 @ExperimentalSerializationApi
-inline fun <reified T : Any> Bundle.getParcelable(key: String, parceler: AndroidParceler): T? {
+inline fun <reified T> Bundle.getParcelable(key: String, parceler: AndroidParceler): T? {
     val bundle = getBundle(key)
-    return bundle?.let { parceler.decodeFromBundle(it) }
+    return bundle?.let { parceler.decodeFromBundle(it, parceler.serializersModule.serializer<T>()) }
 }
 
 @ExperimentalSerializationApi
-inline fun <reified T : Any> Bundle.getParcelable(key: String, parcelable: Parcelable = Parcelable.Default): T? {
+inline fun <reified T> Bundle.getParcelable(key: String, parcelable: Parcelable = Parcelable.Default): T? {
     val bundle = getBundle(key)
-    return bundle?.let { parcelable.decodeFromBundle(it) }
+    return bundle?.let { parcelable.decodeFromBundle(it, parcelable.serializersModule.serializer<T>()) }
 }
 
 @ExperimentalSerializationApi
-fun <T : Any> Bundle.getParcelable(
+fun <T> Bundle.getParcelable(
     key: String,
     parcelable: Parcelable = Parcelable.Default,
     deserializer: DeserializationStrategy<T>

--- a/parcelable-core/src/androidMain/kotlin/com/chrynan/parcelable/core/AndroidIntentUtils.kt
+++ b/parcelable-core/src/androidMain/kotlin/com/chrynan/parcelable/core/AndroidIntentUtils.kt
@@ -8,18 +8,18 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationStrategy
 
 @ExperimentalSerializationApi
-inline fun <reified T : Any> Intent.putExtra(key: String, value: T, parceler: AndroidParceler) {
+inline fun <reified T> Intent.putExtra(key: String, value: T, parceler: AndroidParceler) {
     putExtra(key, parceler.encodeToBundle(value))
 }
 
 @ExperimentalSerializationApi
-inline fun <reified T : Any> Intent.putExtra(key: String, value: T, parcelable: Parcelable = Parcelable.Default) {
+inline fun <reified T> Intent.putExtra(key: String, value: T, parcelable: Parcelable = Parcelable.Default) {
     val bundle = parcelable.encodeToBundle(value)
     putExtra(key, bundle)
 }
 
 @ExperimentalSerializationApi
-fun <T : Any> Intent.putExtra(
+fun <T> Intent.putExtra(
     key: String,
     value: T,
     parcelable: Parcelable = Parcelable.Default,
@@ -30,19 +30,19 @@ fun <T : Any> Intent.putExtra(
 }
 
 @ExperimentalSerializationApi
-inline fun <reified T : Any> Intent.getParcelableExtra(key: String, parceler: AndroidParceler): T? {
+inline fun <reified T> Intent.getParcelableExtra(key: String, parceler: AndroidParceler): T? {
     val bundle = getBundleExtra(key)
     return bundle?.let { parceler.decodeFromBundle(it) }
 }
 
 @ExperimentalSerializationApi
-inline fun <reified T : Any> Intent.getParcelableExtra(key: String, parcelable: Parcelable = Parcelable): T? {
+inline fun <reified T> Intent.getParcelableExtra(key: String, parcelable: Parcelable = Parcelable): T? {
     val bundle = getBundleExtra(key)
     return bundle?.let { parcelable.decodeFromBundle(it) }
 }
 
 @ExperimentalSerializationApi
-fun <T : Any> Intent.getParcelableExtra(
+fun <T> Intent.getParcelableExtra(
     key: String,
     parcelable: Parcelable = Parcelable,
     deserializer: DeserializationStrategy<T>

--- a/parcelable-core/src/androidMain/kotlin/com/chrynan/parcelable/core/AndroidParcelBundleBaseUtils.kt
+++ b/parcelable-core/src/androidMain/kotlin/com/chrynan/parcelable/core/AndroidParcelBundleBaseUtils.kt
@@ -68,7 +68,7 @@ fun <T : Any> AndroidParceler.encodeToBundle(value: T, kClass: KClass<T>): Bundl
  * [Bundle]s.
  */
 @ExperimentalSerializationApi
-fun <T : Any> AndroidParceler.encodeToBundle(value: T, serializer: SerializationStrategy<T>): Bundle {
+fun <T> AndroidParceler.encodeToBundle(value: T, serializer: SerializationStrategy<T>): Bundle {
     // Create a new Bundle and obtain a Parcel from the Parcel Pool.
     val bundle = Bundle()
     val parcel = Parcel.obtain()
@@ -155,7 +155,7 @@ fun <T : Any> AndroidParceler.decodeFromBundle(bundle: Bundle, kClass: KClass<T>
  * if the [bundle] is empty or
  */
 @ExperimentalSerializationApi
-fun <T : Any> AndroidParceler.decodeFromBundle(
+fun <T> AndroidParceler.decodeFromBundle(
     bundle: Bundle,
     deserializer: DeserializationStrategy<T>,
     flags: Int = 0

--- a/parcelable-core/src/androidMain/kotlin/com/chrynan/parcelable/core/AndroidParcelBundleDecodingUtils.kt
+++ b/parcelable-core/src/androidMain/kotlin/com/chrynan/parcelable/core/AndroidParcelBundleDecodingUtils.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
 import kotlin.reflect.KClass
+import kotlinx.serialization.serializer
 
 @ExperimentalSerializationApi
 fun <T : Any> AndroidParceler.decodeFromBundleOrNull(bundle: Bundle, kClass: KClass<T>, flags: Int = 0): T? =
@@ -17,13 +18,13 @@ fun <T : Any> AndroidParceler.decodeFromBundleOrNull(bundle: Bundle, kClass: KCl
     }
 
 @ExperimentalSerializationApi
-inline fun <reified T : Any> AndroidParceler.decodeFromBundle(bundle: Bundle, flags: Int = 0): T =
-    decodeFromBundle(bundle, T::class, flags)
+inline fun <reified T> AndroidParceler.decodeFromBundle(bundle: Bundle, flags: Int = 0): T =
+    decodeFromBundle(bundle, serializersModule.serializer(), flags)
 
 @ExperimentalSerializationApi
-inline fun <reified T : Any> AndroidParceler.decodeFromBundleOrNull(bundle: Bundle, flags: Int = 0): T? =
+inline fun <reified T> AndroidParceler.decodeFromBundleOrNull(bundle: Bundle, flags: Int = 0): T? =
     try {
-        decodeFromBundle(bundle, T::class, flags)
+        decodeFromBundle(bundle, flags)
     } catch (e: SerializationException) {
         null
     }
@@ -48,37 +49,37 @@ fun <T : Any> Parcelable.decodeFromBundleOrNull(
     }
 
 @ExperimentalSerializationApi
-inline fun <reified T : Any> Parcelable.decodeFromBundle(
+inline fun <reified T> Parcelable.decodeFromBundle(
     bundle: Bundle,
     flags: Int = 0
-): T = AndroidParceler(this).decodeFromBundle(bundle, flags)
+): T = decodeFromBundle(bundle, serializersModule.serializer(), flags)
 
 @ExperimentalSerializationApi
-fun <T : Any> Parcelable.decodeFromBundle(
+fun <T> Parcelable.decodeFromBundle(
     bundle: Bundle,
     deserializer: DeserializationStrategy<T>,
     flags: Int = 0
 ): T = AndroidParceler(this).decodeFromBundle(bundle, deserializer, flags)
 
 @ExperimentalSerializationApi
-inline fun <reified T : Any> Parcelable.decodeFromBundleOrNull(
+inline fun <reified T> Parcelable.decodeFromBundleOrNull(
     bundle: Bundle,
     flags: Int = 0
 ): T? =
     try {
-        AndroidParceler(this).decodeFromBundle(bundle, flags)
+        decodeFromBundle(bundle, flags)
     } catch (e: Exception) {
         null
     }
 
 @ExperimentalSerializationApi
-fun <T : Any> Parcelable.decodeFromBundleOrNull(
+fun <T> Parcelable.decodeFromBundleOrNull(
     bundle: Bundle,
     flags: Int = 0,
     deserializer: DeserializationStrategy<T>
 ): T? =
     try {
-        AndroidParceler(this).decodeFromBundle(bundle, deserializer, flags)
+        decodeFromBundle(bundle, deserializer, flags)
     } catch (e: Exception) {
         null
     }

--- a/parcelable-core/src/androidMain/kotlin/com/chrynan/parcelable/core/AndroidParcelBundleEncodingUtils.kt
+++ b/parcelable-core/src/androidMain/kotlin/com/chrynan/parcelable/core/AndroidParcelBundleEncodingUtils.kt
@@ -6,18 +6,20 @@ import android.os.Bundle
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationStrategy
 import kotlin.reflect.KClass
+import kotlinx.serialization.serializer
 
 @ExperimentalSerializationApi
-inline fun <reified T : Any> AndroidParceler.encodeToBundle(value: T): Bundle = encodeToBundle(value, T::class)
+inline fun <reified T> AndroidParceler.encodeToBundle(value: T): Bundle =
+    encodeToBundle(value, serializersModule.serializer())
 
 @ExperimentalSerializationApi
 fun <T : Any> Parcelable.encodeToBundle(value: T, kClass: KClass<T>): Bundle =
     AndroidParceler(this).encodeToBundle(value, kClass)
 
 @ExperimentalSerializationApi
-inline fun <reified T : Any> Parcelable.encodeToBundle(value: T): Bundle =
+inline fun <reified T> Parcelable.encodeToBundle(value: T): Bundle =
     AndroidParceler(this).encodeToBundle(value)
 
 @ExperimentalSerializationApi
-fun <T : Any> Parcelable.encodeToBundle(value: T, serializer: SerializationStrategy<T>): Bundle =
+fun <T> Parcelable.encodeToBundle(value: T, serializer: SerializationStrategy<T>): Bundle =
     AndroidParceler(this).encodeToBundle(value, serializer)

--- a/parcelable-core/src/androidMain/kotlin/com/chrynan/parcelable/core/AndroidParceler.kt
+++ b/parcelable-core/src/androidMain/kotlin/com/chrynan/parcelable/core/AndroidParceler.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationStrategy
 import kotlin.reflect.KClass
+import kotlinx.serialization.modules.SerializersModule
 
 /**
  * A class bridging the serialization logic between the [Parcelable] interface in this library and the Android
@@ -15,6 +16,8 @@ import kotlin.reflect.KClass
 class AndroidParceler(
     private val parcelable: Parcelable
 ) {
+    val serializersModule: SerializersModule
+        get() = parcelable.serializersModule
 
     /**
      * Retrieves the value of [T] represented by the provided [kClass] from the underlying [android.os.Parcel] using
@@ -27,7 +30,7 @@ class AndroidParceler(
      * Retrieves the value of [T] represented by the provided [deserializer] from the underlying [android.os.Parcel] using
      * the [parcelable] instance.
      */
-    fun <T : Any> createFromParcel(source: android.os.Parcel, deserializer: DeserializationStrategy<T>): T =
+    fun <T> createFromParcel(source: android.os.Parcel, deserializer: DeserializationStrategy<T>): T =
         parcelable.decodeFromParcel(source, deserializer)
 
     /**
@@ -41,14 +44,14 @@ class AndroidParceler(
      * Writes the provided [value], represented by the provided [serializer], to the [dest] [android.os.Parcel] using
      * the [parcelable] instance.
      */
-    fun <T : Any> writeToParcel(value: T, dest: android.os.Parcel, serializer: SerializationStrategy<T>) =
+    fun <T> writeToParcel(value: T, dest: android.os.Parcel, serializer: SerializationStrategy<T>) =
         parcelable.encodeToParcel(dest, serializer, value)
 
     /**
      * Retrieves a new empty array for type [T].
      */
     @Suppress("UNCHECKED_CAST")
-    fun <T : Any> newArray(size: Int): Array<T?> = arrayOfNulls<Any?>(size) as Array<T?>
+    fun <T> newArray(size: Int): Array<T> = arrayOfNulls<Any?>(size) as Array<T>
 
     /**
      * Retrieves the [hashCode] for the provided [value] used to describe it's contents in the underlying

--- a/sample-compose/build.gradle.kts
+++ b/sample-compose/build.gradle.kts
@@ -1,6 +1,6 @@
 import com.chrynan.parcelable.buildSrc.LibraryConstants
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.compose.compose
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("multiplatform") // kotlin("jvm") doesn't work well in IDEA/AndroidStudio (https://github.com/JetBrains/compose-jb/issues/22)
@@ -85,6 +85,15 @@ android {
 
     sourceSets["test"].java.srcDirs("src/androidTest/kotlin")
     sourceSets["test"].res.srcDirs("src/androidTest/res")
+}
+
+compose {
+    desktop {
+        application {
+            mainClass = "com.chrynan.parcelable.sample.compose.MainKt"
+            from(kotlin.targets.getByName("jvm"))
+        }
+    }
 }
 
 tasks.withType<Jar> { duplicatesStrategy = DuplicatesStrategy.WARN }


### PR DESCRIPTION
Fixes #3 

Relax the type constraint on `encodeToBundle` and `decodeFromBundle` functions that use `KSerializer<T>` or look up serializers via `serializersModule`.

Align the type constraint on `rememberSaveable` and `Saver` to match upstream compose; there is still an `: Any` constraint for `rememberSaveable<T : Any> : T` but there is none on `rememberSaveable<T> : MutableState<T>`.

Also, quickly configure the desktop version of `sample-compose` for easy testing. 